### PR TITLE
Add -qq to apt-get to reduce log noise

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -54,7 +54,7 @@ else
 fi
 
 APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"
-APT_OPTIONS="$APT_OPTIONS -o dir::etc::sourcelist=$APT_SOURCES"
+APT_OPTIONS="-qq $APT_OPTIONS -o dir::etc::sourcelist=$APT_SOURCES"
 
 topic "Updating apt caches"
 apt-get $APT_OPTIONS update | indent


### PR DESCRIPTION
The Heroku build logs are getting truncated and not showing the entire error. Adding a `-qq` option to reduce the amount of informational noise, and hopefully that means that more of the build log will show up in the console